### PR TITLE
提高识别精度

### DIFF
--- a/autograb.py
+++ b/autograb.py
@@ -91,7 +91,7 @@ def image_link_ocr(image_link):
     i_w, i_h = image.size
     image = image.resize((i_w * 10, i_h *10), Image.ANTIALIAS)
     res = pytesseract.image_to_string(image)
-    res = res.replace('[|','0').replace('|]','0').replace('I','1').replace('l','1').replace('B','6').replace('!','1').replace('|','1').replace('Z','2').replace('H','9').replace('E','5').replace(" ",'').replace("\n",'').replace("\r",'')
+    res = res.replace('[|','0').replace('|]','0').replace('I','1').replace('l','1').replace('B','6').replace('!','1').replace('|','1').replace('Z','2').replace('H','9').replace('E','5')
     os.remove(image_link)
     logging.debug(res)
 

--- a/autograb.py
+++ b/autograb.py
@@ -18,7 +18,7 @@ import re
 import logging
 import traceback
 try:
-    import pytesser as  pytesseract
+    import pytesseract
     from PIL import Image
 except ImportError:
     print '模块导入错误,请使用pip安装,pytesseract依赖以下库：'

--- a/autograb.py
+++ b/autograb.py
@@ -18,7 +18,7 @@ import re
 import logging
 import traceback
 try:
-    import pytesseract
+    import pytesser as  pytesseract
     from PIL import Image
 except ImportError:
     print '模块导入错误,请使用pip安装,pytesseract依赖以下库：'
@@ -88,7 +88,10 @@ def get_captcha_from_live(headers):
 #----------------------------------------------------------------------
 def image_link_ocr(image_link):
     image = Image.open(image_link)
+    i_w, i_h = image.size
+    image = image.resize((i_w * 10, i_h *10), Image.ANTIALIAS)
     res = pytesseract.image_to_string(image)
+    res = res.replace('[|','0').replace('|]','0').replace('I','1').replace('l','1').replace('B','6').replace('!','1').replace('|','1').replace('Z','2').replace('H','9').replace('E','5').replace(" ",'').replace("\n",'').replace("\r",'')
     os.remove(image_link)
     logging.debug(res)
 
@@ -169,7 +172,7 @@ def usage():
     -c: Cookies:
     默认: ./bilicookies
     Cookie的位置
-    
+
     -l: 除错log
     默认: INFO
     INFO/DEBUG


### PR DESCRIPTION
图片太小有的识别会返回空字符串，所以修改了图片大小
直接识别成功率感人，把经常识别错误的字母修正了，但是像9识别成3这就真没办法了。